### PR TITLE
ci: build and deploy from GitHub Actions instead of Dokploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Reinstalled / regenerated inside the image
+node_modules
+.next
+
+# bunfig.toml sets minimumReleaseAge, a guard for interactive `bun add` in dev.
+# The image installs from a frozen lockfile where nothing is resolved, so it can
+# only cause surprises.
+bunfig.toml
+
+# Version control / CI
+.git
+.gitignore
+.github
+
+# Local env & secrets. Runtime env comes from Dokploy; build-time values come
+# from build-args. Without this, a local .env would be baked into a published
+# GHCR image — Next also copies it into .next/standalone.
+.env
+.env.*
+!.env.example
+
+# Infra & tooling that runs in CI or locally, never in the image.
+# scripts/dokploy-preview.mjs only ever runs on a GitHub runner.
+scripts
+docker-compose.yml
+Dockerfile
+.dockerignore
+.dokploy
+
+# Tests
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx
+e2e
+playwright.config.ts
+test-results
+playwright-report
+
+# Docs, editor & OS cruft
+*.md
+.vscode
+.claude
+.DS_Store
+**/.DS_Store
+tsconfig.tsbuildinfo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,12 @@ on:
 # feature branch run alongside a master push, and if their two API calls
 # interleave, production can end up pinned to the wrong image.
 #
-# Production deploys queue rather than cancel. Cancelling mid-run can leave the
-# app pinned to an image whose deploy was never triggered, so the Dokploy record
-# and what is actually serving disagree. Waiting is the cheaper failure.
+# cancel-in-progress is off so a RUNNING deploy is never interrupted part-way
+# between saveDockerProvider and application.deploy, which would leave the app
+# pinned to an image whose deploy never fired. GitHub still keeps only one
+# pending run per group and supersedes an older pending one; that is fine here,
+# because on two quick pushes to master the newer commit is the one that
+# should reach production.
 concurrency:
   group: deploy-production
   cancel-in-progress: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,13 @@ on:
 # application.deploy). A ref-keyed group would let a workflow_dispatch from a
 # feature branch run alongside a master push, and if their two API calls
 # interleave, production can end up pinned to the wrong image.
+#
+# Production deploys queue rather than cancel. Cancelling mid-run can leave the
+# app pinned to an image whose deploy was never triggered, so the Dokploy record
+# and what is actually serving disagree. Waiting is the cheaper failure.
 concurrency:
   group: deploy-production
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,9 @@ env:
 
 jobs:
   build-and-deploy:
+    # workflow_dispatch can be started from any ref, and this job deploys
+    # straight to production, so refuse anything that is not master.
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     # Without this the job inherits GitHub's 6h default, so a Dokploy endpoint
     # that accepts the connection and then stalls would hold a runner all day.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # Without this the job inherits GitHub's 6h default, so a Dokploy endpoint
+    # that accepts the connection and then stalls would hold a runner all day.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -88,7 +91,8 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           IMAGE_REF: ${{ steps.meta.outputs.image }}:${{ github.sha }}
         run: |
-          curl --fail --show-error --silent -X POST \
+          curl --fail --show-error --silent \
+            --proto '=https' --connect-timeout 10 --max-time 60 -X POST \
             "${DOKPLOY_URL}/api/application.saveDockerProvider" \
             -H "x-api-key: ${DOKPLOY_API_KEY}" \
             -H "Content-Type: application/json" \
@@ -100,7 +104,8 @@ jobs:
 
           # Partial update — `env` is deliberately not sent, so the runtime
           # config stays owned by the Dokploy UI.
-          curl --fail --show-error --silent -X POST \
+          curl --fail --show-error --silent \
+            --proto '=https' --connect-timeout 10 --max-time 60 -X POST \
             "${DOKPLOY_URL}/api/application.update" \
             -H "x-api-key: ${DOKPLOY_API_KEY}" \
             -H "Content-Type: application/json" \
@@ -112,7 +117,8 @@ jobs:
           DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
           DOKPLOY_APPLICATION_ID: ${{ secrets.DOKPLOY_APPLICATION_ID }}
         run: |
-          curl --fail --show-error --silent -X POST \
+          curl --fail --show-error --silent \
+            --proto '=https' --connect-timeout 10 --max-time 60 -X POST \
             "${DOKPLOY_URL}/api/application.deploy" \
             -H "x-api-key: ${DOKPLOY_API_KEY}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,119 @@
+name: Build & Deploy (Dokploy)
+
+# Build the production image on a GitHub runner (NOT on the Dokploy server),
+# push it to GHCR, then tell Dokploy to pull and redeploy. This keeps the
+# CPU/RAM-heavy build off the production box, so the live site stays responsive
+# while a deploy runs. Dokploy previously built this with nixpacks.
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Keyed on the deploy target, not the ref. There is exactly one production
+# Dokploy application, and every run mutates it (saveDockerProvider, then
+# application.deploy). A ref-keyed group would let a workflow_dispatch from a
+# feature branch run alongside a master push, and if their two API calls
+# interleave, production can end up pinned to the wrong image.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+  # Build-time values below are inlined into the client bundle, so they are
+  # public by definition and live here rather than in secrets. They must stay in
+  # sync with the Dokploy app's env.
+#   NEXT_PUBLIC_GITHUB_CLIENT_ID — OAuth client IDs are public
+#   NEXT_PUBLIC_ENCRYPTION_KEY — ends up in the client bundle, but this repo is public — keep it out of the workflow file
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          # PAT with write:packages — the package is user-owned, so the
+          # per-repo GITHUB_TOKEN can't push to it. The PAT owner can.
+          username: michaelbonner
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Image metadata (lowercase repo)
+        id: meta
+        run: echo "image=$(echo "${IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          # The Dokploy host is x86_64; a single-arch build keeps this fast.
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.meta.outputs.image }}:latest
+            ${{ steps.meta.outputs.image }}:${{ github.sha }}
+          build-args: |
+            NEXT_PUBLIC_GITHUB_CLIENT_ID=Ov23litckzREulGIMe3j
+            NEXT_PUBLIC_ENCRYPTION_KEY=${{ secrets.NEXT_PUBLIC_ENCRYPTION_KEY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Point the app at the exact image this run produced rather than :latest,
+      # so a redeploy from the Dokploy UI replays this commit instead of
+      # whatever happens to be tagged latest at that moment.
+      #
+      # The application.update call is what keeps the app on the Docker
+      # provider: it is idempotent, so it both performs the original cutover
+      # from the nixpacks/github source and re-asserts it if anyone flips the
+      # app back in the UI. autoDeploy stays off because deploys are triggered
+      # explicitly below, once the image is actually pushed. Dokploy's built-in
+      # preview deployments are turned off here too — preview.yml replaces them,
+      # and leaving both on would build every PR twice, once on the prod box.
+      - name: Pin Dokploy to this commit's image
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          DOKPLOY_APPLICATION_ID: ${{ secrets.DOKPLOY_APPLICATION_ID }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          IMAGE_REF: ${{ steps.meta.outputs.image }}:${{ github.sha }}
+        run: |
+          curl --fail --show-error --silent -X POST \
+            "${DOKPLOY_URL}/api/application.saveDockerProvider" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc \
+                  --arg id "$DOKPLOY_APPLICATION_ID" \
+                  --arg image "$IMAGE_REF" \
+                  --arg pass "$GHCR_TOKEN" \
+                  '{applicationId:$id, dockerImage:$image, registryUrl:"ghcr.io", username:"michaelbonner", password:$pass}')"
+
+          # Partial update — `env` is deliberately not sent, so the runtime
+          # config stays owned by the Dokploy UI.
+          curl --fail --show-error --silent -X POST \
+            "${DOKPLOY_URL}/api/application.update" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"applicationId\":\"${DOKPLOY_APPLICATION_ID}\",\"sourceType\":\"docker\",\"autoDeploy\":false,\"isPreviewDeploymentsActive\":false}"
+
+      - name: Trigger Dokploy deploy
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          DOKPLOY_APPLICATION_ID: ${{ secrets.DOKPLOY_APPLICATION_ID }}
+        run: |
+          curl --fail --show-error --silent -X POST \
+            "${DOKPLOY_URL}/api/application.deploy" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"applicationId\":\"${DOKPLOY_APPLICATION_ID}\"}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,12 +12,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
-# Build/deploy runs for a PR supersede each other, but teardown gets its own
-# group: sharing one would let a new push cancel an in-flight teardown and
-# strand the preview app and its container with nothing left to remove them.
+# One group per PR, and nothing cancels. Both alternatives are worse: sharing a
+# group with cancel-in-progress lets a new push kill an in-flight teardown and
+# strand the preview app, while separate groups let teardown and a deploy run at
+# once, so a close racing a push can delete an app mid-create or recreate one
+# just deleted. Serialising costs a redundant build on rapid pushes, which is
+# the cheapest of the three failures.
 concurrency:
-  group: preview-${{ github.event.number }}-${{ github.event.action == 'closed' && 'teardown' || 'deploy' }}
-  cancel-in-progress: ${{ github.event.action != 'closed' }}
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: false
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -145,7 +145,12 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
+            // Also match on author: the marker is just an HTML comment, so a PR
+            // author could put it in their own comment and have the workflow
+            // edit that instead of posting its own.
+            const existing = comments.find(c =>
+              c.body && c.body.includes(marker) && c.user && c.user.login === 'github-actions[bot]'
+            );
             if (existing) {
               await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
             } else {
@@ -209,7 +214,12 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
+            // Also match on author: the marker is just an HTML comment, so a PR
+            // author could put it in their own comment and have the workflow
+            // edit that instead of posting its own.
+            const existing = comments.find(c =>
+              c.body && c.body.includes(marker) && c.user && c.user.login === 'github-actions[bot]'
+            );
             if (existing) {
               await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
             } else {

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,9 +12,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+# Build/deploy runs for a PR supersede each other, but teardown gets its own
+# group: sharing one would let a new push cancel an in-flight teardown and
+# strand the preview app and its container with nothing left to remove them.
 concurrency:
-  group: preview-${{ github.event.number }}
-  cancel-in-progress: true
+  group: preview-${{ github.event.number }}-${{ github.event.action == 'closed' && 'teardown' || 'deploy' }}
+  cancel-in-progress: ${{ github.event.action != 'closed' }}
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
@@ -29,8 +32,14 @@ env:
 jobs:
   # ---- Build + deploy preview (PR opened / updated / reopened) ----
   preview:
-    if: github.event.action != 'closed'
+    # `pull_request` withholds secrets from fork PRs, so on a fork the GHCR
+    # login and the Dokploy calls would fail on empty values — a red check that
+    # can never go green. Skip instead of failing.
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -104,7 +113,9 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const url = `https://${{ steps.vars.outputs.host }}`;
+            // Taken from the deploy step rather than rebuilt from the host, so
+            // the URL commented here is the one the script actually deployed.
+            const url = '${{ steps.deploy.outputs.preview_url }}';
             const marker = '<!-- dokploy-preview -->';
             const body = `${marker}\n🚀 **Preview deployed:** ${url}\n\n` +
               `_Built off-server in CI and deployed to Dokploy. Updated on every push; removed when this PR closes._`;
@@ -120,8 +131,11 @@ jobs:
 
   # ---- Teardown preview (PR closed / merged) ----
   teardown:
-    if: github.event.action == 'closed'
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,11 +48,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Compute identifiers
+      # Only the image ref: the preview host is the script's to decide, and the
+      # PR comment reads it back from the deploy step's preview_url output.
+      # Computing it a second time here would let the two drift.
+      - name: Compute image name
         id: vars
-        run: |
-          echo "image=$(echo "${IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-          echo "host=grv-${{ github.event.number }}.${PREVIEW_HOST_SUFFIX}" >> "$GITHUB_OUTPUT"
+        run: echo "image=$(echo "${IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -83,15 +84,30 @@ jobs:
 
       # Run the orchestration script from the BASE branch, not the PR, so a PR
       # cannot modify code that executes with DOKPLOY_API_KEY in scope.
-      # (Bootstrap: if the script isn't on the base branch yet, fall back to
-      # the PR copy.)
+      #
+      # This FAILS the job when the trusted copy can't be obtained. Silently
+      # falling back to the PR's copy would hand PR-controlled code the
+      # deployment secrets and defeat the entire point of the step. Until this
+      # script exists on the base branch, the one-time bootstrap is an explicit,
+      # auditable opt-in: set repository variable PREVIEW_ALLOW_PR_SCRIPT=true,
+      # then remove it once this PR merges.
+      #
+      # base_ref and the variable go through env rather than being interpolated
+      # into the shell, so a crafted branch name can't inject commands here.
       - name: Use trusted orchestration script (base branch)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          ALLOW_PR_SCRIPT: ${{ vars.PREVIEW_ALLOW_PR_SCRIPT }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1 || true
-          if git checkout "origin/${{ github.base_ref }}" -- scripts/dokploy-preview.mjs 2>/dev/null; then
-            echo "Using trusted scripts/dokploy-preview.mjs from ${{ github.base_ref }}"
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --depth=1
+          if git checkout "origin/$BASE_REF" -- scripts/dokploy-preview.mjs; then
+            echo "Using trusted scripts/dokploy-preview.mjs from $BASE_REF"
+          elif [ "$ALLOW_PR_SCRIPT" = 'true' ]; then
+            echo "::warning::scripts/dokploy-preview.mjs is not on $BASE_REF; running the PR's copy because PREVIEW_ALLOW_PR_SCRIPT=true. Bootstrap only — unset this after merge."
           else
-            echo "::warning::scripts/dokploy-preview.mjs not on ${{ github.base_ref }} yet; using PR copy (bootstrap)"
+            echo "::error::scripts/dokploy-preview.mjs is not on $BASE_REF, so there is no trusted copy to run. Refusing to execute the PR's copy with deployment secrets in scope. For the one-time bootstrap, set repository variable PREVIEW_ALLOW_PR_SCRIPT=true."
+            exit 1
           fi
 
       - name: Create/update + deploy preview app
@@ -119,8 +135,12 @@ jobs:
             const marker = '<!-- dokploy-preview -->';
             const body = `${marker}\n🚀 **Preview deployed:** ${url}\n\n` +
               `_Built off-server in CI and deployed to Dokploy. Updated on every push; removed when this PR closes._`;
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginated: listComments returns only the first page, so on a long
+            // PR the marker could sit past it and every run would add another
+            // comment instead of editing the one already there.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
@@ -143,14 +163,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # Use the base-branch (trusted) script with the deploy secrets in scope.
+      # Same trusted-script rule as the deploy job, and the same reason to fail
+      # closed: teardown runs with DOKPLOY_API_KEY and deletes an application,
+      # so it is the last place to run PR-controlled code.
       - name: Use trusted orchestration script (base branch)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          ALLOW_PR_SCRIPT: ${{ vars.PREVIEW_ALLOW_PR_SCRIPT }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1 || true
-          if git checkout "origin/${{ github.base_ref }}" -- scripts/dokploy-preview.mjs 2>/dev/null; then
-            echo "Using trusted scripts/dokploy-preview.mjs from ${{ github.base_ref }}"
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --depth=1
+          if git checkout "origin/$BASE_REF" -- scripts/dokploy-preview.mjs; then
+            echo "Using trusted scripts/dokploy-preview.mjs from $BASE_REF"
+          elif [ "$ALLOW_PR_SCRIPT" = 'true' ]; then
+            echo "::warning::scripts/dokploy-preview.mjs is not on $BASE_REF; running the PR's copy because PREVIEW_ALLOW_PR_SCRIPT=true. Bootstrap only — unset this after merge."
           else
-            echo "::warning::scripts/dokploy-preview.mjs not on ${{ github.base_ref }} yet; using PR copy (bootstrap)"
+            echo "::error::scripts/dokploy-preview.mjs is not on $BASE_REF, so there is no trusted copy to run. Refusing to execute the PR's copy with deployment secrets in scope. For the one-time bootstrap, set repository variable PREVIEW_ALLOW_PR_SCRIPT=true."
+            exit 1
           fi
 
       - name: Delete preview app
@@ -170,8 +199,12 @@ jobs:
           script: |
             const marker = '<!-- dokploy-preview -->';
             const body = `${marker}\n🧹 Preview environment for this PR has been torn down.`;
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginated: listComments returns only the first page, so on a long
+            // PR the marker could sit past it and every run would add another
+            // comment instead of editing the one already there.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,167 @@
+name: PR Preview (Dokploy)
+
+# Per-PR preview environments, built off-server in CI (same model as
+# production): build the image on a GitHub runner -> push it to GHCR -> create
+# or update a per-PR Dokploy app (Docker provider) at grv-<n>.bootpack.work
+# -> deploy. On PR close, the per-PR app is deleted.
+#
+# This replaces Dokploy's built-in preview deployments, which built every PR
+# with nixpacks on the production box. deploy.yml turns those off.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+  # Non-secret Dokploy identifiers: the Github Repositories Viewer project and its "preview"
+  # environment, which holds the per-PR apps (name-isolated from the production
+  # app, which lives in the "production" environment).
+  DOKPLOY_PREVIEW_PROJECT_ID: WeAYj-bMv1aJ3Til0U4sv
+  DOKPLOY_PREVIEW_ENVIRONMENT_ID: rW0RJB71286CHNMmW17hW
+  # Wildcard DNS + Let's Encrypt already cover *.bootpack.work.
+  PREVIEW_HOST_SUFFIX: bootpack.work
+
+jobs:
+  # ---- Build + deploy preview (PR opened / updated / reopened) ----
+  preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Compute identifiers
+        id: vars
+        run: |
+          echo "image=$(echo "${IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          echo "host=grv-${{ github.event.number }}.${PREVIEW_HOST_SUFFIX}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          # PAT with write:packages — the package is user-owned, so the
+          # per-repo GITHUB_TOKEN can't push to it.
+          username: michaelbonner
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build & push preview image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.vars.outputs.image }}:pr-${{ github.event.number }}
+            ${{ steps.vars.outputs.image }}:pr-${{ github.event.number }}-${{ github.sha }}
+          build-args: |
+            NEXT_PUBLIC_GITHUB_CLIENT_ID=Ov23litckzREulGIMe3j
+            NEXT_PUBLIC_ENCRYPTION_KEY=${{ secrets.NEXT_PUBLIC_ENCRYPTION_KEY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Run the orchestration script from the BASE branch, not the PR, so a PR
+      # cannot modify code that executes with DOKPLOY_API_KEY in scope.
+      # (Bootstrap: if the script isn't on the base branch yet, fall back to
+      # the PR copy.)
+      - name: Use trusted orchestration script (base branch)
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+          if git checkout "origin/${{ github.base_ref }}" -- scripts/dokploy-preview.mjs 2>/dev/null; then
+            echo "Using trusted scripts/dokploy-preview.mjs from ${{ github.base_ref }}"
+          else
+            echo "::warning::scripts/dokploy-preview.mjs not on ${{ github.base_ref }} yet; using PR copy (bootstrap)"
+          fi
+
+      - name: Create/update + deploy preview app
+        id: deploy
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          DOKPLOY_TEMPLATE_APPLICATION_ID: ${{ secrets.DOKPLOY_APPLICATION_ID }}
+          DOKPLOY_PREVIEW_PROJECT_ID: ${{ env.DOKPLOY_PREVIEW_PROJECT_ID }}
+          DOKPLOY_PREVIEW_ENVIRONMENT_ID: ${{ env.DOKPLOY_PREVIEW_ENVIRONMENT_ID }}
+          PREVIEW_HOST_SUFFIX: ${{ env.PREVIEW_HOST_SUFFIX }}
+          GHCR_USERNAME: michaelbonner
+          GHCR_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          IMAGE: ${{ steps.vars.outputs.image }}:pr-${{ github.event.number }}-${{ github.sha }}
+        run: node scripts/dokploy-preview.mjs deploy
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const url = `https://${{ steps.vars.outputs.host }}`;
+            const marker = '<!-- dokploy-preview -->';
+            const body = `${marker}\n🚀 **Preview deployed:** ${url}\n\n` +
+              `_Built off-server in CI and deployed to Dokploy. Updated on every push; removed when this PR closes._`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }
+
+  # ---- Teardown preview (PR closed / merged) ----
+  teardown:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Use the base-branch (trusted) script with the deploy secrets in scope.
+      - name: Use trusted orchestration script (base branch)
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1 || true
+          if git checkout "origin/${{ github.base_ref }}" -- scripts/dokploy-preview.mjs 2>/dev/null; then
+            echo "Using trusted scripts/dokploy-preview.mjs from ${{ github.base_ref }}"
+          else
+            echo "::warning::scripts/dokploy-preview.mjs not on ${{ github.base_ref }} yet; using PR copy (bootstrap)"
+          fi
+
+      - name: Delete preview app
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          DOKPLOY_TEMPLATE_APPLICATION_ID: ${{ secrets.DOKPLOY_APPLICATION_ID }}
+          DOKPLOY_PREVIEW_PROJECT_ID: ${{ env.DOKPLOY_PREVIEW_PROJECT_ID }}
+          DOKPLOY_PREVIEW_ENVIRONMENT_ID: ${{ env.DOKPLOY_PREVIEW_ENVIRONMENT_ID }}
+          PREVIEW_HOST_SUFFIX: ${{ env.PREVIEW_HOST_SUFFIX }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: node scripts/dokploy-preview.mjs teardown
+
+      - name: Comment teardown on PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- dokploy-preview -->';
+            const body = `${marker}\n🧹 Preview environment for this PR has been torn down.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1
+
+# =====================================================================
+# Production image for Github Repositories Viewer.
+#
+# Built in GitHub Actions (see .github/workflows/deploy.yml) and pushed to
+# GHCR; Dokploy only pulls and runs it. Previously Dokploy built this on the
+# production box with nixpacks, which put a full `next build` on the same
+# CPU and RAM as the live site on every push.
+#
+# Dependencies are installed with bun, because bun.lock is the source of truth
+# for this repo. The build and the server then run on Node: bun segfaults
+# inside `next build` for some of these apps (verified on both amd64 and
+# arm64), and Node is what Next targets anyway.
+# =====================================================================
+FROM oven/bun:1 AS dependencies
+WORKDIR /app
+
+# Dependencies first so this layer caches until the lockfile moves.
+# --ignore-scripts: nothing here needs a postinstall, and running one on a
+# toolchain-free base is a failure waiting to happen.
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --ignore-scripts
+
+FROM node:22-slim AS build
+WORKDIR /app
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY . .
+
+# Build-time values. NEXT_PUBLIC_* is inlined into the client bundle, so it has
+# to be present now rather than at container start.
+ARG NEXT_PUBLIC_GITHUB_CLIENT_ID
+ARG NEXT_PUBLIC_ENCRYPTION_KEY
+ENV NEXT_PUBLIC_GITHUB_CLIENT_ID=$NEXT_PUBLIC_GITHUB_CLIENT_ID \
+    NEXT_PUBLIC_ENCRYPTION_KEY=$NEXT_PUBLIC_ENCRYPTION_KEY
+
+# `next build` imports server modules to collect route metadata, so anything
+# evaluated at import time has to be satisfiable. These placeholders are scoped
+# to this RUN, so they never land in the image's ENV; the real values arrive
+# from Dokploy as container env when the container starts.
+#
+# `npm run build` rather than `next build` directly, so the package.json build
+# script (and any flags it carries) stays the single definition of the build.
+RUN DATABASE_URL=postgresql://build:build@127.0.0.1:5432/build \
+    GITHUB_CLIENT_SECRET=build-time-placeholder \
+    OPENAI_API_KEY=build-time-placeholder \
+    npm run build
+
+# =====================================================================
+# Runtime — `output: "standalone"` (see next.config) emits server.js plus only
+# the dependencies Next traced as reachable, so the runtime stage does not need
+# node_modules at all.
+# =====================================================================
+FROM node:22-slim AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+
+EXPOSE 3000
+
+# Serve only — the same thing nixpacks did. `db:migrate` is still run by hand
+# against this app's database; nothing migrates on boot, so a deploy can never
+# change the schema on its own.
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@
 # inside `next build` for some of these apps (verified on both amd64 and
 # arm64), and Node is what Next targets anyway.
 # =====================================================================
-FROM oven/bun:1 AS dependencies
+# Both Node stages resolve the same base through one ARG so they cannot drift
+# apart, and so there is a single place to pin. Override to pin an exact image:
+#   docker build --build-arg NODE_IMAGE=node:22-slim@sha256:<digest> .
+ARG BUN_IMAGE=oven/bun:1
+ARG NODE_IMAGE=node:22-slim
+
+FROM ${BUN_IMAGE} AS dependencies
 WORKDIR /app
 
 # Dependencies first so this layer caches until the lockfile moves.
@@ -22,7 +28,7 @@ WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --ignore-scripts
 
-FROM node:22-slim AS build
+FROM ${NODE_IMAGE} AS build
 WORKDIR /app
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY . .
@@ -33,6 +39,9 @@ ARG NEXT_PUBLIC_GITHUB_CLIENT_ID
 ARG NEXT_PUBLIC_ENCRYPTION_KEY
 ENV NEXT_PUBLIC_GITHUB_CLIENT_ID=$NEXT_PUBLIC_GITHUB_CLIENT_ID \
     NEXT_PUBLIC_ENCRYPTION_KEY=$NEXT_PUBLIC_ENCRYPTION_KEY
+
+# Fail the build rather than inline an empty per-environment value.
+RUN test -n "$NEXT_PUBLIC_ENCRYPTION_KEY" || { echo "NEXT_PUBLIC_ENCRYPTION_KEY build-arg is required"; exit 1; }
 
 # `next build` imports server modules to collect route metadata, so anything
 # evaluated at import time has to be satisfiable. These placeholders are scoped
@@ -51,15 +60,20 @@ RUN DATABASE_URL=postgresql://build:build@127.0.0.1:5432/build \
 # the dependencies Next traced as reachable, so the runtime stage does not need
 # node_modules at all.
 # =====================================================================
-FROM node:22-slim AS runtime
+FROM ${NODE_IMAGE} AS runtime
 WORKDIR /app
 
 ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \
     PORT=3000
 
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
+# The base image ships an unprivileged `node` user (uid/gid 1000) but still
+# defaults to root. Copy with that ownership and drop to it, so the server does
+# not run as root inside the container. Ownership matters as well as the USER:
+# Next writes into .next at runtime.
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
+USER node
 
 EXPOSE 3000
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  // Emit a self-contained server bundle so the Docker image can ship just the
+  // traced dependencies instead of the whole node_modules tree. See Dockerfile.
+  output: "standalone",
+}
 
 module.exports = nextConfig

--- a/scripts/dokploy-preview.mjs
+++ b/scripts/dokploy-preview.mjs
@@ -312,7 +312,7 @@ required('DOKPLOY_URL', DOKPLOY_URL);
 // Matches --proto '=https' on the workflow's curl calls: this script sends the
 // API key and the GHCR password to this host, so a misconfigured http:// value
 // must fail before any of it goes out in cleartext.
-if (!/^https:///i.test(DOKPLOY_URL)) {
+if (!DOKPLOY_URL.toLowerCase().startsWith('https://')) {
 	console.error(`DOKPLOY_URL must be https:// (got ${DOKPLOY_URL.split('://')[0]}://).`);
 	process.exit(1);
 }

--- a/scripts/dokploy-preview.mjs
+++ b/scripts/dokploy-preview.mjs
@@ -71,12 +71,23 @@ async function call(path, { method = 'POST', query, body } = {}) {
 		body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined
 	});
 	const text = await res.text();
-	if (!res.ok) throw new Error(`${method} /api/${path} -> ${res.status}: ${text.slice(0, 500)}`);
 	let json;
 	try {
 		json = text ? JSON.parse(text) : null;
 	} catch {
 		json = text;
+	}
+
+	// Never put the raw body in the error. application.one returns the app's
+	// whole env, so echoing a response into a CI log could publish every secret
+	// this app holds. Dokploy's errors carry a message/code, which is the useful
+	// part anyway; anything else degrades to the status alone.
+	if (!res.ok) {
+		const detail =
+			json && typeof json === 'object'
+				? [json.message, json.code].filter(Boolean).join(' ') || '(no message)'
+				: '(no message)';
+		throw new Error(`${method} /api/${path} -> ${res.status}: ${detail}`);
 	}
 	// Unwrap the { success, message, data } envelope when present.
 	return json && typeof json === 'object' && 'data' in json ? json.data : json;
@@ -149,6 +160,22 @@ function materializePreviewEnv(env) {
 	return materialized;
 }
 
+// The host:port/dbname a connection URL actually points at, or null if it will
+// not parse. Two URLs can differ byte-for-byte and still reach the same physical
+// database — a ?sslmode= param, different credentials, a host alias — so raw
+// string equality is not enough to tell a preview DB from the production one.
+//
+// WHATWG URL splits userinfo on the LAST '@', so a literal unescaped '@' in the
+// password (some of these have one) still leaves host and database name intact.
+function dbTarget(url) {
+	try {
+		const u = new URL(url);
+		return `${u.hostname}:${u.port}/${u.pathname.replace(/^\/+|\/+$/g, '')}`;
+	} catch {
+		return null;
+	}
+}
+
 // Defense in depth: refuse to deploy a preview whose DB is the production DB.
 function assertPreviewDb(previewEnv, prodEnv) {
 	const previewDb = getEnvValue(previewEnv, 'DATABASE_URL');
@@ -156,9 +183,18 @@ function assertPreviewDb(previewEnv, prodEnv) {
 	if (!previewDb) {
 		throw new Error('Preview env has no DATABASE_URL; refusing to deploy.');
 	}
-	if (prodDb && previewDb === prodDb) {
+
+	const previewTarget = dbTarget(previewDb);
+	if (!previewTarget) {
+		throw new Error('Preview DATABASE_URL is not a parsable URL; refusing to deploy.');
+	}
+
+	// Raw equality still catches the case where production's URL is unparsable
+	// and so has no target to compare against.
+	const prodTarget = dbTarget(prodDb);
+	if (previewDb === prodDb || (prodTarget && previewTarget === prodTarget)) {
 		throw new Error(
-			'Preview DATABASE_URL equals the production DATABASE_URL; refusing to deploy a preview against the production database.'
+			`Preview DATABASE_URL points at the production database (${previewTarget}); refusing to deploy a preview against it.`
 		);
 	}
 }
@@ -185,14 +221,28 @@ async function ensureDomain(appId) {
 	});
 }
 
+// Scoped to the preview environment, never the whole project. The production app
+// lives in the "production" environment of this same project, so a name match
+// across all environments could resolve to it — and `teardown` deletes whatever
+// this returns. Matching only inside DOKPLOY_PREVIEW_ENVIRONMENT_ID keeps the
+// blast radius inside the preview environment no matter what an app is called.
 async function findAppId() {
 	const project = await query('project.one', { projectId: DOKPLOY_PREVIEW_PROJECT_ID });
-	for (const environment of project.environments || []) {
-		const apps = environment.applications || environment.services?.applications || [];
-		const match = apps.find((a) => a.name === APP_NAME);
-		if (match) return match.applicationId;
+	const environment = (project.environments || []).find(
+		(e) => e.environmentId === DOKPLOY_PREVIEW_ENVIRONMENT_ID
+	);
+
+	// A missing environment means misconfiguration, not "no preview app yet".
+	// Returning null there would make deploy create an app and teardown silently
+	// skip, leaving previews stranded; fail loudly instead.
+	if (!environment) {
+		throw new Error(
+			`Preview environment ${DOKPLOY_PREVIEW_ENVIRONMENT_ID} not found in project ${DOKPLOY_PREVIEW_PROJECT_ID}.`
+		);
 	}
-	return null;
+
+	const apps = environment.applications || environment.services?.applications || [];
+	return apps.find((a) => a.name === APP_NAME)?.applicationId ?? null;
 }
 
 async function deploy() {

--- a/scripts/dokploy-preview.mjs
+++ b/scripts/dokploy-preview.mjs
@@ -57,8 +57,12 @@ function required(name, value) {
 async function call(path, { method = 'POST', query, body } = {}) {
 	let url = `${DOKPLOY_URL}/api/${path}`;
 	if (query) url += '?' + new URLSearchParams(query).toString();
+	// Without a timeout, a Dokploy endpoint that accepts the connection and then
+	// never answers hangs the job. That is worst on teardown, where it would
+	// leave the preview app and its container running with nothing to remove them.
 	const res = await fetch(url, {
 		method,
+		signal: AbortSignal.timeout(60_000),
 		headers: {
 			'x-api-key': DOKPLOY_API_KEY,
 			'Content-Type': 'application/json',
@@ -159,6 +163,28 @@ function assertPreviewDb(previewEnv, prodEnv) {
 	}
 }
 
+// Attaching the host runs on every deploy, not just on create. If domain.create
+// ever failed after application.create succeeded, the app would exist from then
+// on, every later run would take the "update" path, and the preview would never
+// get a host — a permanently broken preview that still reports success.
+async function ensureDomain(appId) {
+	const domains = await query('domain.byApplicationId', { applicationId: appId });
+	if (Array.isArray(domains) && domains.some((d) => d.host === HOST)) return;
+
+	console.log(`Attaching ${HOST} to ${APP_NAME}...`);
+	await call('domain.create', {
+		body: {
+			applicationId: appId,
+			domainType: 'application',
+			host: HOST,
+			port: APP_PORT,
+			https: true,
+			certificateType: 'letsencrypt',
+			stripPath: false
+		}
+	});
+}
+
 async function findAppId() {
 	const project = await query('project.one', { projectId: DOKPLOY_PREVIEW_PROJECT_ID });
 	for (const environment of project.environments || []) {
@@ -196,17 +222,6 @@ async function deploy() {
 		await call('application.update', {
 			body: { applicationId: appId, sourceType: 'docker', autoDeploy: false, env }
 		});
-		await call('domain.create', {
-			body: {
-				applicationId: appId,
-				domainType: 'application',
-				host: HOST,
-				port: APP_PORT,
-				https: true,
-				certificateType: 'letsencrypt',
-				stripPath: false
-			}
-		});
 	} else {
 		console.log(`Updating existing preview app ${APP_NAME} (${appId})...`);
 		await call('application.saveDockerProvider', { body: { applicationId: appId, ...creds } });
@@ -214,6 +229,10 @@ async function deploy() {
 			body: { applicationId: appId, sourceType: 'docker', autoDeploy: false, env }
 		});
 	}
+
+	// Throws on failure, which exits non-zero — better a failed run than a
+	// "successful" one advertising a URL that resolves to nothing.
+	await ensureDomain(appId);
 
 	await call('application.deploy', { body: { applicationId: appId } });
 	console.log(`Deployed. Preview URL: https://${HOST}`);

--- a/scripts/dokploy-preview.mjs
+++ b/scripts/dokploy-preview.mjs
@@ -170,7 +170,12 @@ function materializePreviewEnv(env) {
 function dbTarget(url) {
 	try {
 		const u = new URL(url);
-		return `${u.hostname}:${u.port}/${u.pathname.replace(/^\/+|\/+$/g, '')}`;
+		// postgres://db/app and postgres://db:5432/app are the same database, so an
+		// implicit port has to normalise to the explicit one — otherwise the two
+		// spellings compare unequal and a production URL slips past the guard.
+		const port =
+			u.port || (u.protocol === 'postgres:' || u.protocol === 'postgresql:' ? '5432' : '');
+		return `${u.hostname}:${port}/${u.pathname.replace(/^\/+|\/+$/g, '')}`;
 	} catch {
 		return null;
 	}
@@ -304,6 +309,13 @@ async function teardown() {
 }
 
 required('DOKPLOY_URL', DOKPLOY_URL);
+// Matches --proto '=https' on the workflow's curl calls: this script sends the
+// API key and the GHCR password to this host, so a misconfigured http:// value
+// must fail before any of it goes out in cleartext.
+if (!/^https:///i.test(DOKPLOY_URL)) {
+	console.error(`DOKPLOY_URL must be https:// (got ${DOKPLOY_URL.split('://')[0]}://).`);
+	process.exit(1);
+}
 required('DOKPLOY_API_KEY', DOKPLOY_API_KEY);
 required('DOKPLOY_TEMPLATE_APPLICATION_ID', DOKPLOY_TEMPLATE_APPLICATION_ID);
 required('DOKPLOY_PREVIEW_PROJECT_ID', DOKPLOY_PREVIEW_PROJECT_ID);

--- a/scripts/dokploy-preview.mjs
+++ b/scripts/dokploy-preview.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// Per-PR preview orchestration for Dokploy.
+//
+// Dokploy's built-in preview deployments build the image on the production
+// box, which is exactly what we moved off it. Instead, CI builds a per-PR
+// image and this script drives Dokploy's API to create/update/delete a
+// Docker-provider app that just pulls it.
+//
+// Usage:
+//   node scripts/dokploy-preview.mjs deploy     # create-or-update + deploy the PR's preview app
+//   node scripts/dokploy-preview.mjs teardown   # delete the PR's preview app
+//
+// Required env:
+//   DOKPLOY_URL                       e.g. https://dokploy.bootpack.dev
+//   DOKPLOY_API_KEY                   Dokploy API key (x-api-key)
+//   DOKPLOY_TEMPLATE_APPLICATION_ID   production app id — its previewEnv is the runtime-env template
+//   DOKPLOY_PREVIEW_PROJECT_ID        project that holds the per-PR apps
+//   DOKPLOY_PREVIEW_ENVIRONMENT_ID    environment (within that project) to create apps in
+//   PR_NUMBER                         pull request number
+//   IMAGE                             full image ref to deploy (deploy command only)
+//   GHCR_USERNAME + GHCR_PASSWORD     GHCR pull credentials for the private image
+// Optional:
+//   GHCR_REGISTRY                     default "ghcr.io"
+//   PREVIEW_HOST_SUFFIX               default "bootpack.work" (wildcard DNS + cert)
+
+const {
+	DOKPLOY_URL,
+	DOKPLOY_API_KEY,
+	DOKPLOY_TEMPLATE_APPLICATION_ID,
+	DOKPLOY_PREVIEW_PROJECT_ID,
+	DOKPLOY_PREVIEW_ENVIRONMENT_ID,
+	PR_NUMBER,
+	IMAGE,
+	GHCR_USERNAME,
+	GHCR_PASSWORD,
+	GHCR_REGISTRY = 'ghcr.io',
+	PREVIEW_HOST_SUFFIX = 'bootpack.work'
+} = process.env;
+
+const command = process.argv[2];
+const APP_NAME = `grv-${PR_NUMBER}`;
+const HOST = `${APP_NAME}.${PREVIEW_HOST_SUFFIX}`;
+const APP_PORT = 3000;
+
+// Values in previewEnv that must resolve to this PR's own host. Anything left
+// pointing at production would send preview auth callbacks to the live site.
+const HOST_DEPENDENT_KEYS = [];
+
+function required(name, value) {
+	if (!value) {
+		console.error(`Missing required env: ${name}`);
+		process.exit(1);
+	}
+}
+
+// Dokploy's generated API uses GET for queries (.one/.all) and POST for mutations.
+async function call(path, { method = 'POST', query, body } = {}) {
+	let url = `${DOKPLOY_URL}/api/${path}`;
+	if (query) url += '?' + new URLSearchParams(query).toString();
+	const res = await fetch(url, {
+		method,
+		headers: {
+			'x-api-key': DOKPLOY_API_KEY,
+			'Content-Type': 'application/json',
+			accept: 'application/json'
+		},
+		body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined
+	});
+	const text = await res.text();
+	if (!res.ok) throw new Error(`${method} /api/${path} -> ${res.status}: ${text.slice(0, 500)}`);
+	let json;
+	try {
+		json = text ? JSON.parse(text) : null;
+	} catch {
+		json = text;
+	}
+	// Unwrap the { success, message, data } envelope when present.
+	return json && typeof json === 'object' && 'data' in json ? json.data : json;
+}
+
+// Read endpoint: try GET (Dokploy's query convention) and fall back to POST.
+async function query(path, params) {
+	try {
+		return await call(path, { method: 'GET', query: params });
+	} catch (err) {
+		const status = Number(String(err.message).match(/-> (\d+):/)?.[1]);
+		if ([400, 404, 405].includes(status)) {
+			return await call(path, { method: 'POST', body: params });
+		}
+		throw err;
+	}
+}
+
+// Pull previewEnv (the runtime env for preview containers) from the production
+// app — one place to edit preview config, editable from the Dokploy UI.
+async function getTemplate() {
+	const app = await query('application.one', {
+		applicationId: DOKPLOY_TEMPLATE_APPLICATION_ID
+	});
+	// Never fall back to the production env: it carries the production
+	// DATABASE_URL, and a preview pointed at it could read and write live data.
+	if (!app.previewEnv || !app.previewEnv.trim()) {
+		throw new Error(
+			'Template app has no previewEnv set; refusing to fall back to production env for a preview.'
+		);
+	}
+	return { previewEnv: app.previewEnv, prodEnv: app.env || '' };
+}
+
+function getEnvValue(env, key) {
+	const m = env.match(new RegExp(`^\\s*${key}=(.*)$`, 'm'));
+	return m ? m[1].trim().replace(/^["']|["']$/g, '') : '';
+}
+
+// previewEnv is written for Dokploy's native preview flow, which substitutes
+// ${{DOKPLOY_DEPLOY_URL}} itself. This script creates plain Docker-provider
+// apps, so that substitution never happens — do it here before saving.
+function materializePreviewEnv(env) {
+	const materialized = env
+		.replaceAll('${{DOKPLOY_DEPLOY_URL}}', HOST)
+		.replaceAll('${{ DOKPLOY_DEPLOY_URL }}', HOST)
+		.replaceAll('${DOKPLOY_DEPLOY_URL}', HOST)
+		.replaceAll('$DOKPLOY_DEPLOY_URL', HOST);
+
+	if (materialized.includes('DOKPLOY_DEPLOY_URL')) {
+		throw new Error(
+			'Preview env still contains DOKPLOY_DEPLOY_URL after host substitution; refusing to deploy.'
+		);
+	}
+
+	// Assert the host-dependent values actually landed on this PR's host. A
+	// stale production URL here silently breaks auth callbacks and redirects.
+	for (const key of HOST_DEPENDENT_KEYS) {
+		const value = getEnvValue(materialized, key);
+		if (!value) {
+			throw new Error(`Preview env is missing ${key}; refusing to deploy.`);
+		}
+		if (value.replace(/\/$/, '') !== `https://${HOST}`) {
+			throw new Error(
+				`Preview ${key} is "${value}", expected "https://${HOST}"; refusing to deploy.`
+			);
+		}
+	}
+
+	return materialized;
+}
+
+// Defense in depth: refuse to deploy a preview whose DB is the production DB.
+function assertPreviewDb(previewEnv, prodEnv) {
+	const previewDb = getEnvValue(previewEnv, 'DATABASE_URL');
+	const prodDb = getEnvValue(prodEnv, 'DATABASE_URL');
+	if (!previewDb) {
+		throw new Error('Preview env has no DATABASE_URL; refusing to deploy.');
+	}
+	if (prodDb && previewDb === prodDb) {
+		throw new Error(
+			'Preview DATABASE_URL equals the production DATABASE_URL; refusing to deploy a preview against the production database.'
+		);
+	}
+}
+
+async function findAppId() {
+	const project = await query('project.one', { projectId: DOKPLOY_PREVIEW_PROJECT_ID });
+	for (const environment of project.environments || []) {
+		const apps = environment.applications || environment.services?.applications || [];
+		const match = apps.find((a) => a.name === APP_NAME);
+		if (match) return match.applicationId;
+	}
+	return null;
+}
+
+async function deploy() {
+	required('IMAGE', IMAGE);
+	required('GHCR_USERNAME', GHCR_USERNAME);
+	required('GHCR_PASSWORD', GHCR_PASSWORD);
+
+	const template = await getTemplate();
+	const env = materializePreviewEnv(template.previewEnv);
+	assertPreviewDb(env, template.prodEnv);
+
+	const creds = {
+		dockerImage: IMAGE,
+		registryUrl: GHCR_REGISTRY,
+		username: GHCR_USERNAME,
+		password: GHCR_PASSWORD
+	};
+
+	let appId = await findAppId();
+	if (!appId) {
+		console.log(`Creating preview app ${APP_NAME}...`);
+		const created = await call('application.create', {
+			body: { name: APP_NAME, environmentId: DOKPLOY_PREVIEW_ENVIRONMENT_ID }
+		});
+		appId = created.applicationId;
+		await call('application.saveDockerProvider', { body: { applicationId: appId, ...creds } });
+		await call('application.update', {
+			body: { applicationId: appId, sourceType: 'docker', autoDeploy: false, env }
+		});
+		await call('domain.create', {
+			body: {
+				applicationId: appId,
+				domainType: 'application',
+				host: HOST,
+				port: APP_PORT,
+				https: true,
+				certificateType: 'letsencrypt',
+				stripPath: false
+			}
+		});
+	} else {
+		console.log(`Updating existing preview app ${APP_NAME} (${appId})...`);
+		await call('application.saveDockerProvider', { body: { applicationId: appId, ...creds } });
+		await call('application.update', {
+			body: { applicationId: appId, sourceType: 'docker', autoDeploy: false, env }
+		});
+	}
+
+	await call('application.deploy', { body: { applicationId: appId } });
+	console.log(`Deployed. Preview URL: https://${HOST}`);
+
+	if (process.env.GITHUB_OUTPUT) {
+		const { appendFileSync } = await import('node:fs');
+		appendFileSync(process.env.GITHUB_OUTPUT, `preview_url=https://${HOST}\n`);
+	}
+}
+
+async function teardown() {
+	const appId = await findAppId();
+	if (!appId) {
+		console.log(`No preview app named ${APP_NAME} to delete.`);
+		return;
+	}
+	await call('application.delete', { body: { applicationId: appId } });
+	console.log(`Deleted preview app ${APP_NAME} (${appId}).`);
+}
+
+required('DOKPLOY_URL', DOKPLOY_URL);
+required('DOKPLOY_API_KEY', DOKPLOY_API_KEY);
+required('DOKPLOY_TEMPLATE_APPLICATION_ID', DOKPLOY_TEMPLATE_APPLICATION_ID);
+required('DOKPLOY_PREVIEW_PROJECT_ID', DOKPLOY_PREVIEW_PROJECT_ID);
+required('DOKPLOY_PREVIEW_ENVIRONMENT_ID', DOKPLOY_PREVIEW_ENVIRONMENT_ID);
+required('PR_NUMBER', PR_NUMBER);
+
+const run = command === 'teardown' ? teardown : command === 'deploy' ? deploy : null;
+if (!run) {
+	console.error('Usage: dokploy-preview.mjs <deploy|teardown>');
+	process.exit(1);
+}
+run().catch((err) => {
+	console.error(err.message || err);
+	process.exit(1);
+});


### PR DESCRIPTION
Moves this repo's build off the Dokploy server and into GitHub Actions, matching
what `festival-things`, `whattodoinsaltlake`, `lazy-uncle`,
`easycustomerfeedback`, `joblisting-app` and `office-lunch-management`
already do.

Dokploy built this app with **nixpacks on the production box**, so every push
competed with the live site for CPU and RAM. Now a GitHub runner builds the
image, pushes it to GHCR, pins the Dokploy app to that exact commit's tag, and
triggers a pull. Dokploy only ever pulls and runs.

### What's here

| File | Purpose |
| --- | --- |
| `Dockerfile` | Production image. Deps install with bun (`bun.lock` is the source of truth). |
| `.dockerignore` | **New and load-bearing** — without it the local `.env` and `node_modules` land in a published image. |
| `.github/workflows/deploy.yml` | Push to `master` → build → GHCR → pin Dokploy → deploy. |
| `.github/workflows/preview.yml` | Per-PR image → preview app at `grv-<pr>.bootpack.work` → deleted on close. |
| `scripts/dokploy-preview.mjs` | Creates/updates/deletes the per-PR Dokploy app. |

The `application.update` call in `deploy.yml` is idempotent: it performs the
cutover to the Docker provider on first run, turns `autoDeploy` off, disables
Dokploy's built-in preview deployments, and re-asserts all three if anyone flips
them back in the UI.

### Runtime behaviour is deliberately unchanged

The container runs exactly what this app runs today — same start command, same
migrate-on-boot behaviour (or absence of it). Only the *place the build happens*
changed, so a rollback is just flipping the app back to the git source in
Dokploy.

### Already done on the Dokploy side

- A `preview` environment was created in this project to hold per-PR apps.
- `DOKPLOY_URL`, `DOKPLOY_API_KEY` and `DOKPLOY_APPLICATION_ID` are set as
  repo secrets. `GHCR_TOKEN` was already present.

### Verified locally

The image was built with Docker and started; the app boots and serves HTTP 200.

### ⚠️ One-time step before previews work

This app's `previewEnv` used to point at the **production** database. It now
points at `github-repositrories-viewer-preview` on the same Postgres service, and
`scripts/dokploy-preview.mjs` refuses to deploy a preview whose `DATABASE_URL`
matches production. Create the database once, from the Dokploy terminal for the
`github-repositories-viewer-db-ulaws7` service:

```sh
createdb -U ghp-user github-repositrories-viewer-preview
```

The preview database starts empty. This app does not migrate on boot (that
behaviour is unchanged), so push the schema to it once as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated production deployments with containerized builds.
  * Added temporary preview environments for pull requests, including preview links and automatic cleanup when work is closed.
  * Improved deployment packaging for faster, more reliable application startup.

* **Chores**
  * Excluded unnecessary build, dependency, environment, and development files from deployment packages.
  * Updated application configuration to support streamlined standalone production hosting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->