### PR TITLE
fix(dashboards): support Space on row links

### DIFF
--- a/src/app/dashboards/page.tsx
+++ b/src/app/dashboards/page.tsx
@@ -337,6 +337,12 @@ export default function DashboardsPage() {
                 href={`/dashboards/${d.id}`}
                 aria-label={`View ${d.name} dashboard`}
                 className="absolute inset-0 rounded-md focus:ring-2 focus:ring-slate-900 focus:outline-hidden"
+                onKeyDown={(event) => {
+                  if (event.key === " ") event.preventDefault();
+                }}
+                onKeyUp={(event) => {
+                  if (event.key === " ") event.currentTarget.click();
+                }}
               />
               <div className="relative pointer-events-none">
                 <Link


### PR DESCRIPTION
## What changed

- Prevent the default page-scroll behavior when Space is pressed on a dashboard row overlay link.
- Activate the overlay link once on Space keyup.
- Preserve the link’s native Enter behavior and existing attributes.

## Why

The full-row overlay is an anchor, so Enter activates it natively, but Space previously scrolled the page instead of opening the dashboard.

## User impact

Keyboard users can now open a focused dashboard row with either Enter or Space.

## Validation

- `bunx tsc --noEmit`
- `bun run test` — 5 tests passed
- `bun run lint`