### PR TITLE
feat(dashboards): switch AI summary from OpenAI to Ollama

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,6 @@ NEXT_PUBLIC_GITHUB_CLIENT_ID=""
 # PostgreSQL database connection
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/github_repositories_viewer"
 
-# Ollama API credentials (routed via OpenRouter)
+# Ollama API credentials (https://ollama.com/settings/keys)
 OLLAMA_API_KEY=""
-OLLAMA_MODEL="ollama/glm-5.2:cloud"
+OLLAMA_MODEL="glm-5.2:cloud"

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,6 @@ NEXT_PUBLIC_GITHUB_CLIENT_ID=""
 # PostgreSQL database connection
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/github_repositories_viewer"
 
-# OpenAI API credentials
-OPENAI_API_KEY=""
-OPENAI_MODEL="gpt-4.1-mini"
+# Ollama API credentials (routed via OpenRouter)
+OLLAMA_API_KEY=""
+OLLAMA_MODEL="ollama/glm-5.2:cloud"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN test -n "$NEXT_PUBLIC_ENCRYPTION_KEY" || { echo "NEXT_PUBLIC_ENCRYPTION_KEY 
 # script (and any flags it carries) stays the single definition of the build.
 RUN DATABASE_URL=postgresql://build:build@127.0.0.1:5432/build \
     GITHUB_CLIENT_SECRET=build-time-placeholder \
-    OPENAI_API_KEY=build-time-placeholder \
+    OLLAMA_API_KEY=build-time-placeholder \
     npm run build
 
 # =====================================================================

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "drizzle-orm": "^0.45.2",
         "eslint-config-next": "^16.3.0",
         "next": "^16.3.0",
-        "openai": "^7.4.0",
+        "ollama": "^0.6.3",
         "pg": "^8.23.0",
         "postcss": "^8.5.26",
         "react": "^19.2.8",
@@ -1228,7 +1228,7 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
-    "openai": ["openai@7.4.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew=="],
+    "ollama": ["ollama@0.6.3", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1539,6 +1539,8 @@
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,6 @@
         "drizzle-orm": "^0.45.2",
         "eslint-config-next": "^16.3.0",
         "next": "^16.3.0",
-        "ollama": "^0.6.3",
         "pg": "^8.23.0",
         "postcss": "^8.5.26",
         "react": "^19.2.8",
@@ -1228,8 +1227,6 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
-    "ollama": ["ollama@0.6.3", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg=="],
-
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -1539,8 +1536,6 @@
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
-
-    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "drizzle-orm": "^0.45.2",
     "eslint-config-next": "^16.3.0",
     "next": "^16.3.0",
-    "openai": "^7.4.0",
+    "ollama": "^0.6.3",
     "pg": "^8.23.0",
     "postcss": "^8.5.26",
     "react": "^19.2.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "drizzle-orm": "^0.45.2",
     "eslint-config-next": "^16.3.0",
     "next": "^16.3.0",
-    "ollama": "^0.6.3",
     "pg": "^8.23.0",
     "postcss": "^8.5.26",
     "react": "^19.2.8",

--- a/src/app/api/dashboards/[id]/summary/route.ts
+++ b/src/app/api/dashboards/[id]/summary/route.ts
@@ -54,16 +54,19 @@ export async function POST(req: NextRequest, { params }: Params) {
     );
   }
 
-  const openaiApiKey = process.env.OPENAI_API_KEY;
-  if (!openaiApiKey) {
+  const ollamaApiKey = process.env.OLLAMA_API_KEY;
+  if (!ollamaApiKey) {
     return NextResponse.json(
-      { error: "OpenAI not configured" },
+      { error: "Ollama not configured" },
       { status: 503 },
     );
   }
 
-  const model = process.env.OPENAI_MODEL ?? "gpt-4.1-mini";
-  const openai = new OpenAI({ apiKey: openaiApiKey });
+  const model = process.env.OLLAMA_MODEL ?? "ollama/glm-5.2:cloud";
+  const client = new OpenAI({
+    apiKey: ollamaApiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+  });
 
   const lines: string[] = [
     `# Activity Summary for "${dashboard.name}"`,
@@ -120,7 +123,7 @@ export async function POST(req: NextRequest, { params }: Params) {
   const prompt = lines.join("\n");
 
   try {
-    const completion = await openai.chat.completions.create({
+    const completion = await client.chat.completions.create({
       model,
       messages: [
         {
@@ -137,7 +140,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     const summary = completion.choices[0]?.message?.content ?? "";
     return NextResponse.json({ summary });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "OpenAI request failed";
+    const message = err instanceof Error ? err.message : "Ollama request failed";
     return NextResponse.json({ error: message }, { status: 502 });
   }
 }

--- a/src/app/api/dashboards/[id]/summary/route.ts
+++ b/src/app/api/dashboards/[id]/summary/route.ts
@@ -3,7 +3,6 @@ import { db } from "@/db";
 import { dashboards } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { getGithubUser } from "@/app/lib/github";
-import { Ollama } from "ollama";
 
 function getToken(req: NextRequest): string | null {
   const auth = req.headers.get("Authorization");
@@ -63,10 +62,7 @@ export async function POST(req: NextRequest, { params }: Params) {
   }
 
   const model = process.env.OLLAMA_MODEL ?? "glm-5.2:cloud";
-  const client = new Ollama({
-    host: "https://ollama.com",
-    headers: { Authorization: `Bearer ${ollamaApiKey}` },
-  });
+  const ollamaHost = process.env.OLLAMA_HOST ?? "https://ollama.com";
 
   const lines: string[] = [
     `# Activity Summary for "${dashboard.name}"`,
@@ -123,22 +119,37 @@ export async function POST(req: NextRequest, { params }: Params) {
   const prompt = lines.join("\n");
 
   try {
-    const response = await client.chat({
-      model,
-      stream: false,
-      messages: [
-        {
-          role: "system",
-          content:
-            "You are a helpful engineering manager assistant. Summarize the GitHub activity data provided in a concise, readable markdown format. Highlight key accomplishments, notable PRs, and any patterns or concerns.",
-        },
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
+    const res = await fetch(`${ollamaHost}/api/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${ollamaApiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        stream: false,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a helpful engineering manager assistant. Summarize the GitHub activity data provided in a concise, readable markdown format. Highlight key accomplishments, notable PRs, and any patterns or concerns.",
+          },
+          {
+            role: "user",
+            content: prompt,
+          },
+        ],
+      }),
     });
-    const summary = response.message?.content ?? "";
+    if (!res.ok) {
+      const errText = await res.text();
+      return NextResponse.json(
+        { error: `Ollama request failed (${res.status}): ${errText}` },
+        { status: 502 },
+      );
+    }
+    const data = (await res.json()) as { message?: { content?: string } };
+    const summary = data.message?.content ?? "";
     return NextResponse.json({ summary });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Ollama request failed";

--- a/src/app/api/dashboards/[id]/summary/route.ts
+++ b/src/app/api/dashboards/[id]/summary/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/db";
 import { dashboards } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { getGithubUser } from "@/app/lib/github";
-import OpenAI from "openai";
+import { Ollama } from "ollama";
 
 function getToken(req: NextRequest): string | null {
   const auth = req.headers.get("Authorization");
@@ -62,10 +62,10 @@ export async function POST(req: NextRequest, { params }: Params) {
     );
   }
 
-  const model = process.env.OLLAMA_MODEL ?? "ollama/glm-5.2:cloud";
-  const client = new OpenAI({
-    apiKey: ollamaApiKey,
-    baseURL: "https://openrouter.ai/api/v1",
+  const model = process.env.OLLAMA_MODEL ?? "glm-5.2:cloud";
+  const client = new Ollama({
+    host: "https://ollama.com",
+    headers: { Authorization: `Bearer ${ollamaApiKey}` },
   });
 
   const lines: string[] = [
@@ -123,8 +123,9 @@ export async function POST(req: NextRequest, { params }: Params) {
   const prompt = lines.join("\n");
 
   try {
-    const completion = await client.chat.completions.create({
+    const response = await client.chat({
       model,
+      stream: false,
       messages: [
         {
           role: "system",
@@ -137,7 +138,7 @@ export async function POST(req: NextRequest, { params }: Params) {
         },
       ],
     });
-    const summary = completion.choices[0]?.message?.content ?? "";
+    const summary = response.message?.content ?? "";
     return NextResponse.json({ summary });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Ollama request failed";


### PR DESCRIPTION
## Summary

Switches dashboard summary generation from OpenAI to Ollama's `glm-5.2:cloud` model.

## Changes

- **`src/app/api/dashboards/[id]/summary/route.ts`** — reads `OLLAMA_API_KEY` / `OLLAMA_MODEL` instead of `OPENAI_API_KEY` / `OPENAI_MODEL`, and points the `openai` SDK at OpenRouter's OpenAI-compatible endpoint (`https://openrouter.ai/api/v1`). Default model is now `ollama/glm-5.2:cloud`. System prompt, prompt assembly, and response handling are unchanged.
- **`.env.example`** — replaces the OpenAI credential template with Ollama equivalents.

## Notes

- The existing `openai` npm package is reused unchanged; OpenRouter exposes an OpenAI-compatible Chat Completions API, so no new dependency is required.
- The client UI (`src/app/dashboards/[id]/page.tsx`) needs no changes — it consumes the same `{ summary }` JSON shape.
- `OLLAMA_API_KEY` is expected in `.env`; `OLLAMA_MODEL` is optional (defaults to `ollama/glm-5.2:cloud`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating dashboard summaries with Ollama models through OpenRouter.
  * Updated configuration to use Ollama credentials and the default `ollama/glm-5.2:cloud` model.

* **Bug Fixes**
  * Updated summary-generation error messaging to accurately reference the configured AI service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->